### PR TITLE
Add ingress class annotation to created ingress objects

### DIFF
--- a/exposestrategy/auto.go
+++ b/exposestrategy/auto.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/restclient"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -23,7 +22,7 @@ const (
 	stackpointIPEnvVar = "BALANCER_IP"
 )
 
-func NewAutoStrategy(exposer, domain string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
+func NewAutoStrategy(exposer, domain string, client KubeClient, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
 
 	exposer, err := getAutoDefaultExposeRule(client)
 	if err != nil {
@@ -44,7 +43,7 @@ func NewAutoStrategy(exposer, domain string, client *client.Client, restClientCo
 	return New(exposer, domain, client, restClientConfig, encoder)
 }
 
-func getAutoDefaultExposeRule(c *client.Client) (string, error) {
+func getAutoDefaultExposeRule(c KubeClient) (string, error) {
 
 	nodes, err := c.Nodes().List(api.ListOptions{})
 	if err != nil {
@@ -67,7 +66,7 @@ func getAutoDefaultExposeRule(c *client.Client) (string, error) {
 	return ingress, nil
 }
 
-func getAutoDefaultDomain(c *client.Client) (string, error) {
+func getAutoDefaultDomain(c KubeClient) (string, error) {
 	nodes, err := c.Nodes().List(api.ListOptions{})
 	if err != nil {
 		return "", errors.Wrap(err, "failed to find any nodes")

--- a/exposestrategy/client.go
+++ b/exposestrategy/client.go
@@ -1,7 +1,7 @@
 package exposestrategy
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+    "k8s.io/kubernetes/pkg/api"
     "k8s.io/kubernetes/pkg/client/restclient"
     "k8s.io/kubernetes/pkg/client/unversioned"
 )

--- a/exposestrategy/client.go
+++ b/exposestrategy/client.go
@@ -1,0 +1,15 @@
+package exposestrategy
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+    "k8s.io/kubernetes/pkg/client/restclient"
+    "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+type KubeClient interface {
+    Patch(pt api.PatchType) *restclient.Request
+    Get() *restclient.Request
+    Ingress(ns string) unversioned.IngressInterface
+    Pods(ns string) unversioned.PodInterface
+    Nodes() unversioned.NodeInterface
+}

--- a/exposestrategy/ingress.go
+++ b/exposestrategy/ingress.go
@@ -72,6 +72,11 @@ func (s *IngressStrategy) Add(svc *api.Service) error {
 	}
 	ingress.Labels["provider"] = "fabric8"
 
+    if ingress.Annotations == nil {
+        ingress.Annotations = map[string]string{}
+    }
+    ingress.Annotations["kubernetes.io/ingress.class"] = "nginx"
+
 	ingress.Spec.Rules = []extensions.IngressRule{}
 	for _, port := range svc.Spec.Ports {
 		rule := extensions.IngressRule{

--- a/exposestrategy/ingress.go
+++ b/exposestrategy/ingress.go
@@ -10,13 +10,12 @@ import (
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/apis/extensions"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
 
 type IngressStrategy struct {
-	client  *client.Client
+	client  KubeClient
 	encoder runtime.Encoder
 
 	domain string
@@ -24,7 +23,7 @@ type IngressStrategy struct {
 
 var _ ExposeStrategy = &IngressStrategy{}
 
-func NewIngressStrategy(client *client.Client, encoder runtime.Encoder, domain string) (*IngressStrategy, error) {
+func NewIngressStrategy(client KubeClient, encoder runtime.Encoder, domain string) (*IngressStrategy, error) {
 	t, err := typeOfMaster(client)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create new ingress strategy")

--- a/exposestrategy/ingress_test.go
+++ b/exposestrategy/ingress_test.go
@@ -1,0 +1,57 @@
+package exposestrategy
+
+import (
+    "io"
+    "fmt"
+    "testing"
+    "k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+)
+
+type Encoder struct {}
+
+func (e Encoder) Encode(obj runtime.Object, w io.Writer) error {
+    return nil
+}
+
+func TestAddIngressCreatesExpectedAnnotations(t *testing.T) {
+    expectedAnnotation := "kubernetes.io/ingress.class"
+    expectedAnnotationValue := "nginx"
+
+    mockClient := NewMockKubeClient()
+
+    encoder := Encoder{}
+    mockService := new(api.Service)
+    mockService.Name = "test"
+    mockService.Namespace = "test"
+
+    ingressStrategy, _ := NewIngressStrategy(mockClient, encoder, "test")
+    ingressStrategy.Add(mockService)
+
+    actions := mockClient.APIClient.Actions()
+    expectedActions := []string{"get", "create"}
+    if len(actions) != len(expectedActions) {
+        t.Error(fmt.Sprintf("Expected %d actions, but got %d.", len(expectedActions), len(actions)))
+    }
+
+    createAction := actions[1].(testclient.CreateAction)
+    createdIngress, ok := createAction.GetObject().(*extensions.Ingress)
+    if !ok {
+        t.Error("Created object was not an Ingress")
+    }
+
+    if createdIngress.Annotations == nil {
+        t.Error("No annotations found")
+    }
+
+    if ingressClass, ok := createdIngress.Annotations[expectedAnnotation]; ok {
+        if ingressClass != expectedAnnotationValue {
+            t.Error(fmt.Sprintf("Expected annotation '%s' to have value '%s' but was '%s'", expectedAnnotation,
+            expectedAnnotationValue, ingressClass))
+        }
+    } else {
+        t.Error(fmt.Sprintf("Expected annotation '%s' not found", expectedAnnotation))
+    }
+}

--- a/exposestrategy/ingress_test.go
+++ b/exposestrategy/ingress_test.go
@@ -5,9 +5,9 @@ import (
     "fmt"
     "testing"
     "k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apis/extensions"
-	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+    "k8s.io/kubernetes/pkg/api"
+    "k8s.io/kubernetes/pkg/apis/extensions"
+    "k8s.io/kubernetes/pkg/client/unversioned/testclient"
 )
 
 type Encoder struct {}
@@ -16,42 +16,87 @@ func (e Encoder) Encode(obj runtime.Object, w io.Writer) error {
     return nil
 }
 
+type AddAnnotationTest struct {
+    ResponseObjects []runtime.Object
+    ExpectedActions []string
+    GetIngress func([]testclient.Action) *extensions.Ingress
+}
+
 func TestAddIngressCreatesExpectedAnnotations(t *testing.T) {
     expectedAnnotation := "kubernetes.io/ingress.class"
     expectedAnnotationValue := "nginx"
-
-    mockClient := NewMockKubeClient()
-
     encoder := Encoder{}
     mockService := new(api.Service)
-    mockService.Name = "test"
-    mockService.Namespace = "test"
+    mockService.Name = "testService"
+    mockService.Namespace = "testNamespace"
 
-    ingressStrategy, _ := NewIngressStrategy(mockClient, encoder, "test")
-    ingressStrategy.Add(mockService)
+    testCases := getAddIngressAnnotationTestCases(t, mockService)
 
-    actions := mockClient.APIClient.Actions()
-    expectedActions := []string{"get", "create"}
-    if len(actions) != len(expectedActions) {
-        t.Error(fmt.Sprintf("Expected %d actions, but got %d.", len(expectedActions), len(actions)))
-    }
+    for _, testCase := range testCases {
+        mockClient := NewMockKubeClient(
+            testCase.ResponseObjects...
+        )
 
-    createAction := actions[1].(testclient.CreateAction)
-    createdIngress, ok := createAction.GetObject().(*extensions.Ingress)
-    if !ok {
-        t.Error("Created object was not an Ingress")
-    }
+        ingressStrategy, _ := NewIngressStrategy(mockClient, encoder, "test")
+        ingressStrategy.Add(mockService)
 
-    if createdIngress.Annotations == nil {
-        t.Error("No annotations found")
-    }
-
-    if ingressClass, ok := createdIngress.Annotations[expectedAnnotation]; ok {
-        if ingressClass != expectedAnnotationValue {
-            t.Error(fmt.Sprintf("Expected annotation '%s' to have value '%s' but was '%s'", expectedAnnotation,
-            expectedAnnotationValue, ingressClass))
+        actions := mockClient.APIClient.Actions()
+        if len(actions) != len(testCase.ExpectedActions) {
+            t.Error(fmt.Sprintf("Expected %d actions, but got %d.", len(testCase.ExpectedActions), len(actions)))
         }
-    } else {
-        t.Error(fmt.Sprintf("Expected annotation '%s' not found", expectedAnnotation))
+
+        for index, actionName := range testCase.ExpectedActions {
+            if actions[index].GetVerb() != actionName {
+                t.Error(fmt.Sprintf("Expected action %d to be %s but was %s", index, actionName, actions[index].GetVerb()))
+            }
+        }
+
+        ingress := testCase.GetIngress(actions)
+        if ingress.Annotations == nil {
+            t.Error("No annotations found")
+        }
+
+        if ingressClass, ok := ingress.Annotations[expectedAnnotation]; ok {
+            if ingressClass != expectedAnnotationValue {
+                t.Error(fmt.Sprintf("Expected annotation '%s' to have value '%s' but was '%s'", expectedAnnotation,
+                expectedAnnotationValue, ingressClass))
+            }
+        } else {
+            t.Error(fmt.Sprintf("Expected annotation '%s' not found", expectedAnnotation))
+        }
+    }
+}
+
+func getAddIngressAnnotationTestCases(t *testing.T, mockService *api.Service) []AddAnnotationTest {
+    return []AddAnnotationTest{
+        {
+            ResponseObjects: nil,
+            ExpectedActions: []string{"get", "create"},
+            GetIngress: func(actions []testclient.Action) *extensions.Ingress {
+                createAction := actions[1].(testclient.CreateAction)
+                createdIngress, ok := createAction.GetObject().(*extensions.Ingress)
+                if !ok {
+                    t.Error("Created object was not an Ingress")
+                }
+                return createdIngress
+            },
+        },
+        {
+            ResponseObjects: []runtime.Object{
+                &extensions.Ingress{ObjectMeta: api.ObjectMeta{
+                    Name: mockService.Name,
+                    Namespace: mockService.Namespace,
+                }},
+            },
+            ExpectedActions: []string{"get", "update"},
+            GetIngress: func(actions []testclient.Action) *extensions.Ingress {
+                updateAction := actions[1].(testclient.UpdateAction)
+                updatedIngress, ok := updateAction.GetObject().(*extensions.Ingress)
+                if !ok {
+                    t.Error("Created object was not an Ingress")
+                }
+                return updatedIngress
+            },
+        },
     }
 }

--- a/exposestrategy/loadbalancer.go
+++ b/exposestrategy/loadbalancer.go
@@ -7,18 +7,17 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/v1"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
 type LoadBalancerStrategy struct {
-	client  *client.Client
+	client  KubeClient
 	encoder runtime.Encoder
 }
 
 var _ ExposeStrategy = &LoadBalancerStrategy{}
 
-func NewLoadBalancerStrategy(client *client.Client, encoder runtime.Encoder) (*LoadBalancerStrategy, error) {
+func NewLoadBalancerStrategy(client KubeClient, encoder runtime.Encoder) (*LoadBalancerStrategy, error) {
 	return &LoadBalancerStrategy{
 		client:  client,
 		encoder: encoder,

--- a/exposestrategy/mock_client.go
+++ b/exposestrategy/mock_client.go
@@ -2,11 +2,12 @@ package exposestrategy
 
 import (
     "strings"
-	"net/http"
+    "net/http"
     "io/ioutil"
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/unversioned/fake"
-	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+    "k8s.io/kubernetes/pkg/api"
+    "k8s.io/kubernetes/pkg/runtime"
+    "k8s.io/kubernetes/pkg/client/unversioned/fake"
+    "k8s.io/kubernetes/pkg/client/unversioned/testclient"
     "k8s.io/kubernetes/pkg/client/restclient"
     "k8s.io/kubernetes/pkg/client/unversioned"
 )
@@ -16,7 +17,7 @@ type MockKubeClient struct {
     APIClient *testclient.Fake
 }
 
-func NewMockKubeClient() MockKubeClient {
+func NewMockKubeClient(responseObjects ...runtime.Object) MockKubeClient {
     restClient := &fake.RESTClient{
         Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
             httpResp := http.Response {
@@ -28,7 +29,7 @@ func NewMockKubeClient() MockKubeClient {
         }),
     }
 
-    fakeClient := testclient.NewSimpleFake()
+    fakeClient := testclient.NewSimpleFake(responseObjects...)
 
     return MockKubeClient{
         RESTClient: restClient,

--- a/exposestrategy/mock_client.go
+++ b/exposestrategy/mock_client.go
@@ -1,0 +1,57 @@
+package exposestrategy
+
+import (
+    "strings"
+	"net/http"
+    "io/ioutil"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+    "k8s.io/kubernetes/pkg/client/restclient"
+    "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+type MockKubeClient struct {
+    RESTClient *fake.RESTClient
+    APIClient *testclient.Fake
+}
+
+func NewMockKubeClient() MockKubeClient {
+    restClient := &fake.RESTClient{
+        Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+            httpResp := http.Response {
+                StatusCode: 200,
+                Body: ioutil.NopCloser(strings.NewReader("Test Response")),
+                Request: req,
+            }
+			return &httpResp, nil
+        }),
+    }
+
+    fakeClient := testclient.NewSimpleFake()
+
+    return MockKubeClient{
+        RESTClient: restClient,
+        APIClient: fakeClient,
+    }
+}
+
+func (c MockKubeClient) Patch(pt api.PatchType) *restclient.Request {
+    return c.RESTClient.Patch(pt)
+}
+
+func (c MockKubeClient) Get() *restclient.Request {
+    return c.RESTClient.Get()
+}
+
+func (c MockKubeClient) Ingress(ns string) unversioned.IngressInterface {
+    return c.APIClient.Extensions().Ingress(ns)
+}
+
+func (c MockKubeClient) Nodes() unversioned.NodeInterface {
+    return c.APIClient.Nodes()
+}
+
+func (c MockKubeClient) Pods(ns string) unversioned.PodInterface {
+    return c.APIClient.Pods(ns)
+}

--- a/exposestrategy/nodeport.go
+++ b/exposestrategy/nodeport.go
@@ -10,12 +10,11 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/v1"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
 type NodePortStrategy struct {
-	client  *client.Client
+	client  KubeClient
 	encoder runtime.Encoder
 
 	nodeIP string
@@ -25,7 +24,7 @@ var _ ExposeStrategy = &NodePortStrategy{}
 
 const ExternalIPLabel = "fabric8.io/externalIP"
 
-func NewNodePortStrategy(client *client.Client, encoder runtime.Encoder) (*NodePortStrategy, error) {
+func NewNodePortStrategy(client KubeClient, encoder runtime.Encoder) (*NodePortStrategy, error) {
 	l, err := client.Nodes().List(api.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list nodes")

--- a/exposestrategy/route.go
+++ b/exposestrategy/route.go
@@ -13,12 +13,11 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/v1"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
 type RouteStrategy struct {
-	client  *client.Client
+	client  KubeClient
 	oclient *oclient.Client
 	encoder runtime.Encoder
 
@@ -27,7 +26,7 @@ type RouteStrategy struct {
 
 var _ ExposeStrategy = &RouteStrategy{}
 
-func NewRouteStrategy(client *client.Client, oclient *oclient.Client, encoder runtime.Encoder, domain string) (*RouteStrategy, error) {
+func NewRouteStrategy(client KubeClient, oclient *oclient.Client, encoder runtime.Encoder, domain string) (*RouteStrategy, error) {
 	t, err := typeOfMaster(client)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create new route strategy")

--- a/exposestrategy/strategy.go
+++ b/exposestrategy/strategy.go
@@ -8,7 +8,6 @@ import (
 	oclient "github.com/openshift/origin/pkg/client"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/restclient"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -27,7 +26,7 @@ var (
 	ExposeAnnotationKey = "fabric8.io/exposeUrl"
 )
 
-func New(exposer, domain string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
+func New(exposer, domain string, client KubeClient, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
 	switch strings.ToLower(exposer) {
 	case "loadbalancer":
 		strategy, err := NewLoadBalancerStrategy(client, encoder)

--- a/exposestrategy/utils.go
+++ b/exposestrategy/utils.go
@@ -9,7 +9,6 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/strategicpatch"
 )
@@ -81,7 +80,7 @@ const (
 	kubernetes masterType = "Kubernetes"
 )
 
-func typeOfMaster(c *client.Client) (masterType, error) {
+func typeOfMaster(c KubeClient) (masterType, error) {
 	res, err := c.Get().AbsPath("").DoRaw()
 	if err != nil {
 		errors.Wrap(err, "could not discover the type of your installation")


### PR DESCRIPTION
The GCE Load-Balancer Controller (GLBC) that comes with GKE Kubernetes clusters will create a Google Load Balancer for every ingress entry that is created unless the ingress has an annotation specifying an ingress class other than gce (see [Disabling GLBC](https://github.com/kubernetes/ingress/blob/master/controllers/gce/BETA_LIMITATIONS.md#disabling-glbc)). This change specifies "nginx" as the ingress class to prevent the GLBC from adding unnecessary load balancers.

P.S. This is my first time writing Go code, so please advise on testing, conventions, etc. I struggled to find a way to test the modified method because of the complex Client object that must be passed in. I imagine it will be simpler when a versioned client can be used that supports patching.