### PR TITLE
add template for ingress and route urls

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	Exposer       string `yaml:"exposer"`
 	ApiServer     string `yaml:"apiserver,omitempty"`
 	AuthorizePath string `yaml:"authorize-path,omitempty"`
+	UrlTemplate   string `yaml:"urltemplate,omitempty"`
 
 	// original is the input from which the config was parsed.
 	original string

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -65,7 +65,14 @@ func NewController(
 		}),
 	}
 
-	strategy, err := exposestrategy.New(config.Exposer, config.Domain, kubeClient, restClientConfig, encoder)
+	strategy, err := exposestrategy.New(
+		config.Exposer,
+		config.Domain,
+		config.UrlTemplate,
+		kubeClient,
+		restClientConfig,
+		encoder,
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create new strategy")
 	}

--- a/examples/config-map.yml
+++ b/examples/config-map.yml
@@ -1,12 +1,14 @@
 apiVersion: "v1"
 data:
   config.yml: |-
-    domain: 
-    exposer: 
+    domain:
+    exposer:
     # exposer: LoadBalancer
     # exposer: Ingress
     # exposer: Route
     # exposer: NodePort
+    # For ingress or route exposers can set the urltemplate to expose
+    # urltemplate: "{{.Service}}.{{.Namespace}}.{{.Domain}}"
 kind: "ConfigMap"
 metadata:
   labels:

--- a/exposestrategy/auto.go
+++ b/exposestrategy/auto.go
@@ -23,7 +23,7 @@ const (
 	stackpointIPEnvVar = "BALANCER_IP"
 )
 
-func NewAutoStrategy(exposer, domain string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
+func NewAutoStrategy(exposer, domain string, urltemplate string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
 
 	exposer, err := getAutoDefaultExposeRule(client)
 	if err != nil {
@@ -41,7 +41,7 @@ func NewAutoStrategy(exposer, domain string, client *client.Client, restClientCo
 		glog.Infof("Using domain: %s", domain)
 	}
 
-	return New(exposer, domain, client, restClientConfig, encoder)
+	return New(exposer, domain, urltemplate, client, restClientConfig, encoder)
 }
 
 func getAutoDefaultExposeRule(c *client.Client) (string, error) {

--- a/exposestrategy/strategy.go
+++ b/exposestrategy/strategy.go
@@ -27,7 +27,7 @@ var (
 	ExposeAnnotationKey = "fabric8.io/exposeUrl"
 )
 
-func New(exposer, domain string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
+func New(exposer, domain string, urltemplate string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
 	switch strings.ToLower(exposer) {
 	case "loadbalancer":
 		strategy, err := NewLoadBalancerStrategy(client, encoder)
@@ -42,7 +42,7 @@ func New(exposer, domain string, client *client.Client, restClientConfig *restcl
 		}
 		return strategy, nil
 	case "ingress":
-		strategy, err := NewIngressStrategy(client, encoder, domain)
+		strategy, err := NewIngressStrategy(client, encoder, domain, urltemplate)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create ingress expose strategy")
 		}
@@ -53,13 +53,13 @@ func New(exposer, domain string, client *client.Client, restClientConfig *restcl
 		ocfg.GroupVersion = nil
 		ocfg.NegotiatedSerializer = nil
 		oc, _ := oclient.New(&ocfg)
-		strategy, err := NewRouteStrategy(client, oc, encoder, domain)
+		strategy, err := NewRouteStrategy(client, oc, encoder, domain, urltemplate)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create ingress expose strategy")
 		}
 		return strategy, nil
 	case "":
-		strategy, err := NewAutoStrategy(exposer, domain, client, restClientConfig, encoder)
+		strategy, err := NewAutoStrategy(exposer, domain, urltemplate, client, restClientConfig, encoder)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create auto expose strategy")
 		}

--- a/exposestrategy/utils.go
+++ b/exposestrategy/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net"
+	"text/template"
 
 	"github.com/pkg/errors"
 
@@ -98,4 +99,27 @@ func typeOfMaster(c *client.Client) (masterType, error) {
 		}
 	}
 	return kubernetes, nil
+}
+
+type urlTemplateParts struct {
+	Service string
+	Namespace string
+	Domain string
+}
+
+func getUrlFormat(urltemplate string) (string, error) {
+	if urltemplate == "" {
+		urltemplate = "{{.Service}}.{{.Namespace}}.{{.Domain}}"
+	}
+	placeholders := urlTemplateParts{"%[1]s", "%[2]s", "%[3]s"}
+	tmpl, err := template.New("format").Parse(urltemplate)
+	if err != nil {
+		errors.Wrap(err, "Failed to parse UrlTemplate")
+	}
+	var buffer bytes.Buffer
+	err = tmpl.Execute(&buffer, placeholders)
+	if err != nil {
+		errors.Wrap(err, "Failed to execute UrlTemplate")
+	}
+	return buffer.String(), nil
 }


### PR DESCRIPTION
The purpose of this PR is to provide a flexible way to change the URL of the generated ingress resources.

Motivation came about when working with a development environment.  We wanted to quickly expose services using a wildcard cert.  To do this we wanted the format to be {{.Service}}-{{.Namespace}}.{{.Domain}} rather than {{.Service}}.{{.Namespace}}.{{.Domain}}.

The changes allow complete flexibility in generating URLs using the .Service, .Namespace and .Domain placeholders.

Am new to GO so welcome any and all advice/direction.