### PR TITLE
feat: expose the hostname as a custom annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,28 @@ __exposecontroller__ will use your `exposer` type in the configmap above to auto
 
 Having an external URL is extremely useful. Here are some other uses of the expose URL in addition to the annotation that gets applied to the `Service`
 
+### Custom annotations
+
+You can add the hostname as a custom annotation on the service, by using the `fabric8.io/exposeHostNameAs` annotation:
+
+```yaml
+metadata:
+  annotations:
+    fabric8.io/exposeHostNameAs: osiris.deislabs.io/ingressHostname
+```
+
+will be converted to:
+
+```yaml
+metadata:
+  annotations:
+    fabric8.io/exposeUrl: https://example.com
+    osiris.deislabs.io/ingressHostname: example.com
+    fabric8.io/exposeHostNameAs: osiris.deislabs.io/ingressHostname
+```
+
+This is useful if you are working with tools which require access to the exposed hostname at the service level, using a specific annotation, such as [Osiris](https://github.com/deislabs/osiris).
+
 ### ConfigMap
 
 Sometimes web applications need to know their external URL so that they can use that link or host/port when generating documentation or links.

--- a/exposestrategy/strategy.go
+++ b/exposestrategy/strategy.go
@@ -24,12 +24,13 @@ type Label struct {
 }
 
 var (
-	ExposeLabel                 = Label{Key: "expose", Value: "true"}
-	ExposeAnnotation            = Label{Key: "fabric8.io/expose", Value: "true"}
-	InjectAnnotation            = Label{Key: "fabric8.io/inject", Value: "true"}
-	ExposeAnnotationKey         = "fabric8.io/exposeUrl"
-	ExposePortAnnotationKey     = "fabric8.io/exposePort"
-	ApiServicePathAnnotationKey = "api.service.kubernetes.io/path"
+	ExposeLabel                   = Label{Key: "expose", Value: "true"}
+	ExposeAnnotation              = Label{Key: "fabric8.io/expose", Value: "true"}
+	InjectAnnotation              = Label{Key: "fabric8.io/inject", Value: "true"}
+	ExposeHostNameAsAnnotationKey = "fabric8.io/exposeHostNameAs"
+	ExposeAnnotationKey           = "fabric8.io/exposeUrl"
+	ExposePortAnnotationKey       = "fabric8.io/exposePort"
+	ApiServicePathAnnotationKey   = "api.service.kubernetes.io/path"
 )
 
 func New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode string, routeUsePath, http, tlsAcme bool, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {

--- a/exposestrategy/utils.go
+++ b/exposestrategy/utils.go
@@ -43,15 +43,20 @@ func addServiceAnnotation(svc *api.Service, hostName string) (*api.Service, erro
 }
 
 func addServiceAnnotationWithProtocol(svc *api.Service, hostName string, protocol string) (*api.Service, error) {
-	exposeURL := protocol + "://" + hostName
 	if svc.Annotations == nil {
 		svc.Annotations = map[string]string{}
 	}
+
+	exposeURL := protocol + "://" + hostName
 	path := svc.Annotations[ApiServicePathAnnotationKey]
 	if len(path) > 0 {
 		exposeURL = urlJoin(exposeURL, path)
 	}
 	svc.Annotations[ExposeAnnotationKey] = exposeURL
+
+	if key := svc.Annotations[ExposeHostNameAsAnnotationKey]; len(key) > 0 {
+		svc.Annotations[key] = hostName
+	}
 
 	return svc, nil
 }
@@ -63,6 +68,9 @@ func urlJoin(repo string, path string) string {
 
 func removeServiceAnnotation(svc *api.Service) *api.Service {
 	delete(svc.Annotations, ExposeAnnotationKey)
+	if key := svc.Annotations[ExposeHostNameAsAnnotationKey]; len(key) > 0 {
+		delete(svc.Annotations, key)
+	}
 
 	return svc
 }

--- a/exposestrategy/utils_test.go
+++ b/exposestrategy/utils_test.go
@@ -1,0 +1,125 @@
+package exposestrategy
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func TestAddServiceAnnotationWithProtocol(t *testing.T) {
+	tests := []struct {
+		svc                 *api.Service
+		hostName            string
+		protocol            string
+		expectedAnnotations map[string]string
+	}{
+		{
+			svc:      &api.Service{},
+			hostName: "example.com",
+			protocol: "http",
+			expectedAnnotations: map[string]string{
+				ExposeAnnotationKey: "http://example.com",
+			},
+		},
+		{
+			svc:      &api.Service{},
+			hostName: "example.com",
+			protocol: "https",
+			expectedAnnotations: map[string]string{
+				ExposeAnnotationKey: "https://example.com",
+			},
+		},
+		{
+			svc: &api.Service{
+				ObjectMeta: api.ObjectMeta{
+					Annotations: map[string]string{
+						ApiServicePathAnnotationKey: "some/path",
+					},
+				},
+			},
+			hostName: "example.com",
+			protocol: "https",
+			expectedAnnotations: map[string]string{
+				ApiServicePathAnnotationKey: "some/path",
+				ExposeAnnotationKey:         "https://example.com/some/path",
+			},
+		},
+		{
+			svc: &api.Service{
+				ObjectMeta: api.ObjectMeta{
+					Annotations: map[string]string{
+						ExposeHostNameAsAnnotationKey: "osiris.deislabs.io/ingressHostname",
+					},
+				},
+			},
+			hostName: "example.com",
+			protocol: "http",
+			expectedAnnotations: map[string]string{
+				ExposeHostNameAsAnnotationKey:        "osiris.deislabs.io/ingressHostname",
+				"osiris.deislabs.io/ingressHostname": "example.com",
+				ExposeAnnotationKey:                  "http://example.com",
+			},
+		},
+	}
+
+	for i, test := range tests {
+		svc, err := addServiceAnnotationWithProtocol(test.svc, test.hostName, test.protocol)
+		if err != nil {
+			t.Errorf("[%d] got unexpected error: %v", i, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(test.expectedAnnotations, svc.Annotations) {
+			t.Errorf("[%d] Got the following annotations %#v but expected %#v", i, svc.Annotations, test.expectedAnnotations)
+		}
+	}
+}
+
+func TestRemoveServiceAnnotation(t *testing.T) {
+	tests := []struct {
+		svc                 *api.Service
+		expectedAnnotations map[string]string
+	}{
+		{
+			svc:                 &api.Service{},
+			expectedAnnotations: nil,
+		},
+		{
+			svc: &api.Service{
+				ObjectMeta: api.ObjectMeta{
+					Annotations: map[string]string{
+						ExposeAnnotationKey: "http://example.com",
+						"some-key":          "some value",
+					},
+				},
+			},
+			expectedAnnotations: map[string]string{
+				"some-key": "some value",
+			},
+		},
+		{
+			svc: &api.Service{
+				ObjectMeta: api.ObjectMeta{
+					Annotations: map[string]string{
+						ExposeHostNameAsAnnotationKey:        "osiris.deislabs.io/ingressHostname",
+						"osiris.deislabs.io/ingressHostname": "example.com",
+						ApiServicePathAnnotationKey:          "some/path",
+						ExposeAnnotationKey:                  "http://example.com/some/path",
+					},
+				},
+			},
+			expectedAnnotations: map[string]string{
+				ExposeHostNameAsAnnotationKey: "osiris.deislabs.io/ingressHostname",
+				ApiServicePathAnnotationKey:   "some/path",
+			},
+		},
+	}
+
+	for i, test := range tests {
+		svc := removeServiceAnnotation(test.svc)
+		if !reflect.DeepEqual(test.expectedAnnotations, svc.Annotations) {
+			t.Errorf("[%d] Got the following annotations %#v but expected %#v", i, svc.Annotations, test.expectedAnnotations)
+		}
+	}
+}


### PR DESCRIPTION
introduce a new annotation `fabric8.io/exposeHostNameAs` which can be used to expose the hostname as a custom annotation:

```yaml
metadata:
  annotations:
    fabric8.io/exposeHostNameAs: osiris.deislabs.io/ingressHostname
```

will be converted to:

```yaml
metadata:
  annotations:
    fabric8.io/exposeUrl: https://example.com
    osiris.deislabs.io/ingressHostname: example.com
    fabric8.io/exposeHostNameAs: osiris.deislabs.io/ingressHostname
```

our use-case is to be able to easily use https://github.com/deislabs/osiris for scaling to 0 unused preview environments in jenkins-x

see original discussion at https://kubernetes.slack.com/archives/C9LTHT2BB/p1545383579014400