### PR TITLE
feature: Added ingress-class option

### DIFF
--- a/charts/exposecontroller/templates/configmap.yaml
+++ b/charts/exposecontroller/templates/configmap.yaml
@@ -11,6 +11,9 @@ data:
 {{- if .Values.config.pathMode }}
     path-mode: {{ .Values.config.pathMode }}
 {{- end }}
+{{- if .Values.config.ingressClass }}
+    ingress-class: {{ .Values.config.ingressClass }}
+{{- end }}
 {{- if .Values.config.urltemplate }}
     urltemplate: {{ .Values.config.urltemplate }}
 {{- end }}

--- a/controller/config.go
+++ b/controller/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	TLSAcme               bool     `yaml:"tls-acme" json:"tls_acme"`
 	UrlTemplate           string   `yaml:"urltemplate,omitempty" json:"url_template"`
 	Services              []string `yaml:"services,omitempty" json:"services"`
+	IngressClass          string   `yaml:"ingress-class" json:"ingress_class"`
 	// original is the input from which the config was parsed.
 	original string `json:"original"`
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -86,7 +86,7 @@ func NewController(
 		}),
 	}
 
-	strategy, err := exposestrategy.New(config.Exposer, config.Domain, config.UrlTemplate, config.NodeIP, config.RouteHost, config.PathMode, config.RouteUsePath, config.HTTP, config.TLSAcme, kubeClient, restClientConfig, encoder)
+	strategy, err := exposestrategy.New(config.Exposer, config.Domain, config.UrlTemplate, config.NodeIP, config.RouteHost, config.PathMode, config.RouteUsePath, config.HTTP, config.TLSAcme, config.IngressClass, kubeClient, restClientConfig, encoder)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create new strategy")
 	}

--- a/exposestrategy/auto.go
+++ b/exposestrategy/auto.go
@@ -23,7 +23,7 @@ const (
 	stackpointIPEnvVar = "BALANCER_IP"
 )
 
-func NewAutoStrategy(exposer, domain, urltemplate string, nodeIP, routeHost, pathMode string, routeUsePath, http, tlsAcme bool, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
+func NewAutoStrategy(exposer, domain, urltemplate string, nodeIP, routeHost, pathMode string, routeUsePath, http, tlsAcme bool, ingressClass string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
 
 	exposer, err := getAutoDefaultExposeRule(client)
 	if err != nil {
@@ -40,7 +40,7 @@ func NewAutoStrategy(exposer, domain, urltemplate string, nodeIP, routeHost, pat
 		glog.Infof("Using domain: %s", domain)
 	}
 
-	return New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode, routeUsePath, http, tlsAcme, client, restClientConfig, encoder)
+	return New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode, routeUsePath, http, tlsAcme, ingressClass, client, restClientConfig, encoder)
 }
 
 func getAutoDefaultExposeRule(c *client.Client) (string, error) {

--- a/exposestrategy/strategy.go
+++ b/exposestrategy/strategy.go
@@ -33,7 +33,7 @@ var (
 	ApiServicePathAnnotationKey   = "api.service.kubernetes.io/path"
 )
 
-func New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode string, routeUsePath, http, tlsAcme bool, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
+func New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode string, routeUsePath, http, tlsAcme bool, ingressClass string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
 	switch strings.ToLower(exposer) {
 	case "loadbalancer":
 		strategy, err := NewLoadBalancerStrategy(client, encoder)
@@ -49,7 +49,7 @@ func New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode string, route
 		return strategy, nil
 	case "ingress":
 		glog.Infof("stratagy.New %v", http)
-		strategy, err := NewIngressStrategy(client, encoder, domain, http, tlsAcme, urltemplate, pathMode)
+		strategy, err := NewIngressStrategy(client, encoder, domain, http, tlsAcme, urltemplate, pathMode, ingressClass)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create ingress expose strategy")
 		}
@@ -66,7 +66,7 @@ func New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode string, route
 		}
 		return strategy, nil
 	case "":
-		strategy, err := NewAutoStrategy(exposer, domain, urltemplate, nodeIP, routeHost, pathMode, routeUsePath, http, tlsAcme, client, restClientConfig, encoder)
+		strategy, err := NewAutoStrategy(exposer, domain, urltemplate, nodeIP, routeHost, pathMode, routeUsePath, http, tlsAcme, ingressClass, client, restClientConfig, encoder)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create auto expose strategy")
 		}


### PR DESCRIPTION
We needed to set the ingress class of created ingresses, so we've implemented the option to configure the ingress class using the configuration yaml file. With this option user can set the ingress annotations "kubernetes.io/ingress.class" and "nginx.ingress.kubernetes.io/ingress.class".

Also added ingressClass to charts/exposecontroller/templates/configmap.yaml, so users can pass this value when installing through helm. (we plan to add a flag to jx to receive the desired ingress class and write it to the generated values files)