### PR TITLE
Add resource limits to job

### DIFF
--- a/charts/exposecontroller/templates/job.yaml
+++ b/charts/exposecontroller/templates/job.yaml
@@ -33,6 +33,13 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 80m
+            memory: 128Mi
         name: {{ .Chart.Name }}
         command: ["/exposecontroller"]
         args: 


### PR DESCRIPTION
This is required when ResourceQuotas are
defined in a namespace.