### PR TITLE
feat(tls): introduce tls-secret-name to enable manual TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ We use a Kubernetes ConfigMap and mutltiple config entries. Full list [here](htt
   - `domain` when using either Kubernetes Ingress or OpenShift Routes you will need to set the domain that you've used with your DNS provider (fabric8 uses [cloudflare](https://www.cloudflare.com)) or nip.io if you want a quick way to get running.
   - `exposer` used to describe which strategy exposecontroller should use to access applications
   - `tls-acme` (boolean) used to enable automatic TLS when used in conjunction with [kube-lego](https://github.com/jetstack/kube-lego). Only works with version v2.3.31 onwards.
+  - `tls-secret-name` (string) used to enabled TLS using a pre-existing TLS secret
 
 ### Automatic
 

--- a/charts/exposecontroller/templates/configmap.yaml
+++ b/charts/exposecontroller/templates/configmap.yaml
@@ -19,6 +19,9 @@ data:
 {{- end }}
     http: {{ .Values.config.http | default true }}
     tls-acme: {{ .Values.config.tlsacme | default false  }}
+{{- if .Values.config.tlsSecretName }}
+    tls-secret-name: {{ .Values.config.tlsSecretName }}
+{{- end }}
 {{- if .Values.config.extravalues }}
 {{ toYaml .Values.config.extravalues | indent 4 }}
 {{- end }}

--- a/controller/config.go
+++ b/controller/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	WatchCurrentNamespace bool     `yaml:"watch-current-namespace" json:"watch_current_namespace"`
 	HTTP                  bool     `yaml:"http" json:"http"`
 	TLSAcme               bool     `yaml:"tls-acme" json:"tls_acme"`
+	TLSSecretName         string   `yaml:"tls-secret-name" json:"tls_secret_name"`
 	UrlTemplate           string   `yaml:"urltemplate,omitempty" json:"url_template"`
 	Services              []string `yaml:"services,omitempty" json:"services"`
 	IngressClass          string   `yaml:"ingress-class" json:"ingress_class"`

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -86,7 +86,7 @@ func NewController(
 		}),
 	}
 
-	strategy, err := exposestrategy.New(config.Exposer, config.Domain, config.UrlTemplate, config.NodeIP, config.RouteHost, config.PathMode, config.RouteUsePath, config.HTTP, config.TLSAcme, config.IngressClass, kubeClient, restClientConfig, encoder)
+	strategy, err := exposestrategy.New(config.Exposer, config.Domain, config.UrlTemplate, config.NodeIP, config.RouteHost, config.PathMode, config.RouteUsePath, config.HTTP, config.TLSAcme, config.TLSSecretName, config.IngressClass, kubeClient, restClientConfig, encoder)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create new strategy")
 	}
@@ -234,7 +234,7 @@ func findApiServerFromNode(c *client.Client) string {
 	}
 	items := nodes.Items
 	if len(items) != 1 {
-		glog.Errorf("Number of nodes is %d. We need 1 to detect minishift. Please use  to list nodes to detect minishift: %v", items, err)
+		glog.Errorf("Number of nodes is %d. We need 1 to detect minishift. Please use  to list nodes to detect minishift: %v", len(items), err)
 		return ""
 	}
 	node := items[0]

--- a/exposestrategy/auto.go
+++ b/exposestrategy/auto.go
@@ -23,7 +23,7 @@ const (
 	stackpointIPEnvVar = "BALANCER_IP"
 )
 
-func NewAutoStrategy(exposer, domain, urltemplate string, nodeIP, routeHost, pathMode string, routeUsePath, http, tlsAcme bool, ingressClass string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
+func NewAutoStrategy(exposer, domain, urltemplate string, nodeIP, routeHost, pathMode string, routeUsePath, http, tlsAcme bool, tlsSecretName, ingressClass string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
 
 	exposer, err := getAutoDefaultExposeRule(client)
 	if err != nil {
@@ -40,7 +40,7 @@ func NewAutoStrategy(exposer, domain, urltemplate string, nodeIP, routeHost, pat
 		glog.Infof("Using domain: %s", domain)
 	}
 
-	return New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode, routeUsePath, http, tlsAcme, ingressClass, client, restClientConfig, encoder)
+	return New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode, routeUsePath, http, tlsAcme, tlsSecretName, ingressClass, client, restClientConfig, encoder)
 }
 
 func getAutoDefaultExposeRule(c *client.Client) (string, error) {

--- a/exposestrategy/strategy.go
+++ b/exposestrategy/strategy.go
@@ -33,10 +33,10 @@ var (
 	ApiServicePathAnnotationKey   = "api.service.kubernetes.io/path"
 )
 
-func New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode string, routeUsePath, http, tlsAcme bool, ingressClass string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
+func New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode string, routeUsePath, http, tlsAcme bool, tlsSecretName, ingressClass string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
 	switch strings.ToLower(exposer) {
 	case "ambassador":
-		strategy, err := NewAmbassadorStrategy(client, encoder, domain, http, tlsAcme, urltemplate, pathMode)
+		strategy, err := NewAmbassadorStrategy(client, encoder, domain, http, tlsAcme, tlsSecretName, urltemplate, pathMode)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create ambassador expose strategy")
 		}
@@ -55,7 +55,7 @@ func New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode string, route
 		return strategy, nil
 	case "ingress":
 		glog.Infof("stratagy.New %v", http)
-		strategy, err := NewIngressStrategy(client, encoder, domain, http, tlsAcme, urltemplate, pathMode, ingressClass)
+		strategy, err := NewIngressStrategy(client, encoder, domain, http, tlsAcme, tlsSecretName, urltemplate, pathMode, ingressClass)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create ingress expose strategy")
 		}
@@ -72,7 +72,7 @@ func New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode string, route
 		}
 		return strategy, nil
 	case "":
-		strategy, err := NewAutoStrategy(exposer, domain, urltemplate, nodeIP, routeHost, pathMode, routeUsePath, http, tlsAcme, ingressClass, client, restClientConfig, encoder)
+		strategy, err := NewAutoStrategy(exposer, domain, urltemplate, nodeIP, routeHost, pathMode, routeUsePath, http, tlsAcme, tlsSecretName, ingressClass, client, restClientConfig, encoder)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create auto expose strategy")
 		}


### PR DESCRIPTION
for the moment, exposecontroller only supports tls-acme for automatic TLS
tls-secret-name enables TLS with a pre-existing TLS secret (certificate)