### PR TITLE
Add example for tls-acme property

### DIFF
--- a/charts/exposecontroller/values.yaml
+++ b/charts/exposecontroller/values.yaml
@@ -5,6 +5,7 @@ Annotations: {}
   # use value of `path` to use path based ingress
 # config:
 #   pathMode: "path"
+#   tlsacme: true
 #   extravalues:
 #     foo: bar
 


### PR DESCRIPTION
Since the property tls-acme has an unexpected name without dash it should be part of the example values