### PR TITLE
Update role.yaml

### DIFF
--- a/charts/exposecontroller/templates/role.yaml
+++ b/charts/exposecontroller/templates/role.yaml
@@ -42,6 +42,7 @@ rules:
   - "route.openshift.io"
   resources:
   - routes
+  - routes/custom-host
   verbs:
   - get
   - list


### PR DESCRIPTION
Fix issue that specify route-host for openshift
Add failed: failed to create route ...: spec.host: Forbidden: you do not have permission to set the host field of the route