### PR TITLE
feat: Add tls wildcard support

### DIFF
--- a/charts/exposecontroller/templates/configmap.yaml
+++ b/charts/exposecontroller/templates/configmap.yaml
@@ -22,6 +22,9 @@ data:
 {{- if .Values.config.tlsSecretName }}
     tls-secret-name: {{ .Values.config.tlsSecretName }}
 {{- end }}
+{{- if .Values.config.tlsUseWildcard }}
+    tls-use-wildcard: {{ .Values.config.tlsUseWildcard }}
+{{- end }}
 {{- if .Values.config.extravalues }}
 {{ toYaml .Values.config.extravalues | indent 4 }}
 {{- end }}

--- a/controller/config.go
+++ b/controller/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	HTTP                  bool     `yaml:"http" json:"http"`
 	TLSAcme               bool     `yaml:"tls-acme" json:"tls_acme"`
 	TLSSecretName         string   `yaml:"tls-secret-name" json:"tls_secret_name"`
+	TLSUseWildcard        bool     `yaml:"tls-use-wildcard" json:"tls_use_wildcard"`
 	UrlTemplate           string   `yaml:"urltemplate,omitempty" json:"url_template"`
 	Services              []string `yaml:"services,omitempty" json:"services"`
 	IngressClass          string   `yaml:"ingress-class" json:"ingress_class"`

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -86,7 +86,7 @@ func NewController(
 		}),
 	}
 
-	strategy, err := exposestrategy.New(config.Exposer, config.Domain, config.UrlTemplate, config.NodeIP, config.RouteHost, config.PathMode, config.RouteUsePath, config.HTTP, config.TLSAcme, config.TLSSecretName, config.IngressClass, kubeClient, restClientConfig, encoder)
+	strategy, err := exposestrategy.New(config.Exposer, config.Domain, config.UrlTemplate, config.NodeIP, config.RouteHost, config.PathMode, config.RouteUsePath, config.HTTP, config.TLSAcme, config.TLSSecretName, config.TLSUseWildcard, config.IngressClass, kubeClient, restClientConfig, encoder)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create new strategy")
 	}

--- a/exposestrategy/auto.go
+++ b/exposestrategy/auto.go
@@ -23,7 +23,7 @@ const (
 	stackpointIPEnvVar = "BALANCER_IP"
 )
 
-func NewAutoStrategy(exposer, domain, urltemplate string, nodeIP, routeHost, pathMode string, routeUsePath, http, tlsAcme bool, tlsSecretName, ingressClass string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
+func NewAutoStrategy(exposer, domain, urltemplate string, nodeIP, routeHost, pathMode string, routeUsePath, http, tlsAcme bool, tlsSecretName string, tlsUseWildcard bool, ingressClass string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
 
 	exposer, err := getAutoDefaultExposeRule(client)
 	if err != nil {
@@ -40,7 +40,7 @@ func NewAutoStrategy(exposer, domain, urltemplate string, nodeIP, routeHost, pat
 		glog.Infof("Using domain: %s", domain)
 	}
 
-	return New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode, routeUsePath, http, tlsAcme, tlsSecretName, ingressClass, client, restClientConfig, encoder)
+	return New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode, routeUsePath, http, tlsAcme, tlsSecretName, tlsUseWildcard, ingressClass, client, restClientConfig, encoder)
 }
 
 func getAutoDefaultExposeRule(c *client.Client) (string, error) {

--- a/exposestrategy/ingress.go
+++ b/exposestrategy/ingress.go
@@ -86,7 +86,7 @@ func (s *IngressStrategy) Add(svc *api.Service) error {
 		}
 	}
 
-	hostName := fmt.Sprintf(s.urltemplate, appName, svc.Namespace, s.domain)
+	hostName = fmt.Sprintf(s.urltemplate, appName, svc.Namespace, s.domain)
 	tlsHostName := hostName
 	if s.tlsUseWildcard {
 		tlsHostName = "*." + s.domain

--- a/exposestrategy/ingress.go
+++ b/exposestrategy/ingress.go
@@ -86,7 +86,12 @@ func (s *IngressStrategy) Add(svc *api.Service) error {
 		}
 	}
 
-	hostName = fmt.Sprintf(s.urltemplate, appName, svc.Namespace, s.domain)
+	hostName := svc.Annotations["fabric8.io/host.name"]
+	if hostName == "" {
+		hostName = appName
+	}
+
+	hostName = fmt.Sprintf(s.urltemplate, hostName, svc.Namespace, s.domain)
 	tlsHostName := hostName
 	if s.tlsUseWildcard {
 		tlsHostName = "*." + s.domain

--- a/exposestrategy/strategy.go
+++ b/exposestrategy/strategy.go
@@ -33,7 +33,7 @@ var (
 	ApiServicePathAnnotationKey   = "api.service.kubernetes.io/path"
 )
 
-func New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode string, routeUsePath, http, tlsAcme bool, tlsSecretName, ingressClass string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
+func New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode string, routeUsePath, http, tlsAcme bool, tlsSecretName string, tlsUseWildcard bool, ingressClass string, client *client.Client, restClientConfig *restclient.Config, encoder runtime.Encoder) (ExposeStrategy, error) {
 	switch strings.ToLower(exposer) {
 	case "ambassador":
 		strategy, err := NewAmbassadorStrategy(client, encoder, domain, http, tlsAcme, tlsSecretName, urltemplate, pathMode)
@@ -55,7 +55,7 @@ func New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode string, route
 		return strategy, nil
 	case "ingress":
 		glog.Infof("stratagy.New %v", http)
-		strategy, err := NewIngressStrategy(client, encoder, domain, http, tlsAcme, tlsSecretName, urltemplate, pathMode, ingressClass)
+		strategy, err := NewIngressStrategy(client, encoder, domain, http, tlsAcme, tlsSecretName, tlsUseWildcard, urltemplate, pathMode, ingressClass)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create ingress expose strategy")
 		}
@@ -72,7 +72,7 @@ func New(exposer, domain, urltemplate, nodeIP, routeHost, pathMode string, route
 		}
 		return strategy, nil
 	case "":
-		strategy, err := NewAutoStrategy(exposer, domain, urltemplate, nodeIP, routeHost, pathMode, routeUsePath, http, tlsAcme, tlsSecretName, ingressClass, client, restClientConfig, encoder)
+		strategy, err := NewAutoStrategy(exposer, domain, urltemplate, nodeIP, routeHost, pathMode, routeUsePath, http, tlsAcme, tlsSecretName, tlsUseWildcard, ingressClass, client, restClientConfig, encoder)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create auto expose strategy")
 		}


### PR DESCRIPTION
This PR addresses the following scenario:

Preview environments shall be enabled to activate TLS support with using wildcard certificates instead of creating certificates for every ingress which may take more than 5 minutes and burn LetsEncrypt quotas.
Therefore wildcard certificates needs to be synchronized to the desired Preview namespace (using kubed, Jenkinsfile, ...) and tls-secret needs to be set as well as the new property: tlsUseWildcard .

Example preview values.yaml

```
  config:
    exposer: Ingress
    http: true
    tlsacme: true
    tlsSecretName: wildcard-cert-tls
    tlsUseWildcard: true
    urltemplate: '"{{.Service}}-{{.Namespace}}.{{.Domain}}"'
```

With activating **tlsUseWildcard**, and changing the urltemplate the resulting ingress looks like this:
```
spec:
  rules:
  - host: test-jx-me-test-pr-1.example.com
    http:
      paths:
      - backend:
          serviceName: test
          servicePort: 80
  tls:
  - hosts:
    - *.example.com
    secretName: wildcard-cert-tls
```

Without using the wildcard tls hostname, certmanager is complaining about wrong domain names.