### PR TITLE
Making job resource configurable in helm chart

### DIFF
--- a/charts/exposecontroller/Chart.yaml
+++ b/charts/exposecontroller/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
 - email: jenkins-x@googlegroups.com
   name: Jenkins X Team
 name: exposecontroller
-version: 2.3.110
+version: 2.3.111

--- a/charts/exposecontroller/Chart.yaml
+++ b/charts/exposecontroller/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
 - email: jenkins-x@googlegroups.com
   name: Jenkins X Team
 name: exposecontroller
-version: 2.3.109
+version: 2.3.110

--- a/charts/exposecontroller/templates/deployment.yaml
+++ b/charts/exposecontroller/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
         image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"
         name: {{ .Chart.Name }}
         command: ["/exposecontroller"]
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
         args:
         - --daemon
 {{- range .Values.Args }}

--- a/charts/exposecontroller/templates/deployment.yaml
+++ b/charts/exposecontroller/templates/deployment.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.RunAsDaemon }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Release.Name }}-{{ .Chart.Name }}"
+{{- if .Values.Annotations }}
+  annotations:
+{{ toYaml .Values.Annotations | indent 4 }}
+{{- end }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: "{{.Release.Name}}"
+      labels:
+        heritage: {{.Release.Service | quote }}
+        release: {{.Release.Name | quote }}
+        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    spec:
+      containers:
+      - env:
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"
+        name: {{ .Chart.Name }}
+        command: ["/exposecontroller"]
+        args:
+        - --daemon
+{{- range .Values.Args }}
+        - {{ . | quote }}
+{{- end }}
+      serviceAccountName: {{ .Chart.Name }}
+{{- end }}

--- a/charts/exposecontroller/templates/job.yaml
+++ b/charts/exposecontroller/templates/job.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.RunAsDaemon }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43,3 +44,4 @@ spec:
 {{- end }}
       serviceAccountName: {{ .Chart.Name }}
       restartPolicy: Never
+{{- end }}

--- a/charts/exposecontroller/templates/job.yaml
+++ b/charts/exposecontroller/templates/job.yaml
@@ -34,12 +34,7 @@ spec:
               fieldPath: metadata.namespace
         image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"
         resources:
-          limits:
-            cpu: 100m
-            memory: 256Mi
-          requests:
-            cpu: 80m
-            memory: 128Mi
+{{ toYaml .Values.resources | indent 8 }}
         name: {{ .Chart.Name }}
         command: ["/exposecontroller"]
         args: 

--- a/charts/exposecontroller/templates/job.yaml
+++ b/charts/exposecontroller/templates/job.yaml
@@ -34,7 +34,7 @@ spec:
               fieldPath: metadata.namespace
         image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"
         resources:
-{{ toYaml .Values.resources | indent 8 }}
+{{ toYaml .Values.resources | indent 10 }}
         name: {{ .Chart.Name }}
         command: ["/exposecontroller"]
         args: 

--- a/charts/exposecontroller/values.yaml
+++ b/charts/exposecontroller/values.yaml
@@ -2,6 +2,15 @@ Image: "gcr.io/jenkinsxio/exposecontroller"
 ImageTag: "latest"
 BackoffLimit: 5
 Annotations: {}
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 256Mi
+  requests:
+    cpu: 80m
+    memory: 128Mi
+
   # use value of `path` to use path based ingress
 # config:
 #   pathMode: "path"

--- a/charts/exposecontroller/values.yaml
+++ b/charts/exposecontroller/values.yaml
@@ -3,6 +3,9 @@ ImageTag: "latest"
 BackoffLimit: 5
 Annotations: {}
 
+# in case to run the helm as a deployment
+RunAsDaemon: false
+
 resources:
   limits:
     cpu: 100m


### PR DESCRIPTION
in the current expose controller job is having hard coded resource values, which sometimes causing timeout issue on everytime we update the repo. Its better to leave it configrable than hard coded. For the sake following existing, in the values.yaml i have added the current values as default.