### PR TITLE
feat: add annotation to specify hostName

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ The ingress URL uses the service name that contains the `expose` annotation, if 
 kubectl annotate svc foo fabric8.io/ingress.name=bar
 ```
 
+### Host name
+
+The ingress URL uses the service name that contains the `expose` annotation, if you want the host name to be different yet be a separate ingress object:
+```sh
+kubectl annotate svc foo fabric8.io/host.name=bar
+```
+
 ### Multiple backend services
 
 An ingress rule can have multiple service backends, traffic is managed using a path see https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource

--- a/exposestrategy/ambassador.go
+++ b/exposestrategy/ambassador.go
@@ -79,7 +79,12 @@ func (s *AmbassadorStrategy) Add(svc *api.Service) error {
 		}
 	}
 
-	hostName := fmt.Sprintf(s.urltemplate, appName, svc.Namespace, s.domain)
+	hostName := svc.Annotations["fabric8.io/host.name"]
+	if hostName == "" {
+		hostName = appName
+	}
+
+	hostName = fmt.Sprintf(s.urltemplate, hostName, svc.Namespace, s.domain)
 	// fullHostName := hostName
 	path := svc.Annotations["fabric8.io/ingress.path"]
 	pathMode := svc.Annotations["fabric8.io/path.mode"]

--- a/exposestrategy/ingress.go
+++ b/exposestrategy/ingress.go
@@ -84,7 +84,12 @@ func (s *IngressStrategy) Add(svc *api.Service) error {
 		}
 	}
 
-	hostName := fmt.Sprintf(s.urltemplate, appName, svc.Namespace, s.domain)
+	hostName := svc.Annotations["fabric8.io/host.name"]
+	if hostName == "" {
+		hostName = appName
+	}
+
+	hostName = fmt.Sprintf(s.urltemplate, hostName, svc.Namespace, s.domain)
 	fullHostName := hostName
 	path := svc.Annotations["fabric8.io/ingress.path"]
 	pathMode := svc.Annotations["fabric8.io/path.mode"]


### PR DESCRIPTION
similar functionality to ingress.name annotation except when multiple
ingress objects on the same host is required

fix #195