### PR TITLE
fix: only issue warning for ingress strategy on openshift

### DIFF
--- a/exposestrategy/ingress.go
+++ b/exposestrategy/ingress.go
@@ -45,7 +45,7 @@ func NewIngressStrategy(client *client.Client, encoder runtime.Encoder, domain s
 		return nil, errors.Wrap(err, "could not create new ingress strategy")
 	}
 	if t == openShift {
-		return nil, errors.New("ingress strategy is not supported on OpenShift, please use Route strategy")
+		glog.Warning("OpenShift platform detected, expose strategy Ingress might not work. Using the Route strategy on OpenShift is recommended.")
 	}
 
 	if len(domain) == 0 {


### PR DESCRIPTION
Any recent OpenShift cluster supports Ingress resources just fine.

Solves issue #200 

Signed-off-by: Joost van der Griendt <joostvdg@gmail.com>